### PR TITLE
feat(genai, rabbitmq): Re-enable actual LLM calls and extend RPC timeout

### DIFF
--- a/docker-var.env
+++ b/docker-var.env
@@ -12,7 +12,7 @@ MONGODB_URI=mongodb://mongo:27017/caidense-synth
 RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672
 RABBITMQ_EXECUTE_QUEUE_NAME=caidense-execution
 RABBITMQ_WORKER_QUEUE_NAME=caidense-worker
-RABBITMQ_RPC_TIMEOUT=5000
+RABBITMQ_RPC_TIMEOUT=60000
 # Configuration of VM (a module of NodeJS)
 VM_TIMEOUT=1000
 # Max number of nodes in a graph

--- a/libs/caidense-reasoning/src/executor/genai/genai.service.ts
+++ b/libs/caidense-reasoning/src/executor/genai/genai.service.ts
@@ -29,41 +29,10 @@ export class LLMCallExecutor extends ExecutorBase {
     const config = node.config as LLMCallNodeConfig;
     const genaiService = await this.moduleRef.resolve(GenaiServiceMap[config.service]);
     const promptText = await this.composePrompt(config.promptTemplate, node, tracker);
-    // const response = await genaiService.generateContentFromAiStudio(promptText, config.modelName)
-    const response = {
-      candidates: [
-        {
-          content: {
-            parts: [
-              {
-                text: "```json\n{\n  \"thinking_summary\": \"使用者提供了初步的願景相關概念。我的目標是針對這些概念，提出一系列開放式問題，以協助使用者更深入地探索其組織的願景、使命和價值觀。這些問題旨在涵蓋願景的關鍵要素，包括目的、影響、未來狀態、獨特性和價值觀。由於這是首次互動，我會專注於廣泛的探索，為後續的討論奠定基礎。\",\n  \"suggested_direction\": \"請仔細思考以下問題，並盡可能詳細地分享您的想法。您的回答將有助於我們共同塑造一個清晰而有力的組織願景。\",\n  \"response_content\": \"感謝您分享這些關鍵概念！為了更深入地探索，並打造一個真正能激勵人心的願景，請思考以下問題：\\n\\n1.  **目的 (Purpose):** 除了盈利之外，您希望您的組織為世界帶來什麼樣的改變？您希望解決什麼樣的問題？\\n2.  **影響 (Impact):** 您希望您的組織對客戶、員工和整個社會產生什麼樣的正面影響？\\n3.  **未來狀態 (Future State):** 展望未來五年、十年甚至更久，您希望您的組織發展成什麼樣？您希望在行業中扮演什麼樣的角色？\\n4.  **獨特性 (Uniqueness):** 是什麼讓您的組織與眾不同？您希望如何利用這些獨特的優勢來實現您的願景？\\n5.  **價值觀 (Values):** 哪些核心價值觀指導著您的組織？這些價值觀如何在日常工作中體現？\\n6.  **團隊協作 (Teamwork):** 您期望團隊協作在實現願景中扮演什麼樣的角色？如何建立一個鼓勵協作和共同成長的環境？\\n7.  **智能策略管理 (Intelligent Strategy Management):** 如何運用數據和科技，提升策略管理的效率和精準度，從而更好地實現願景？\",\n  \"next_turn_history_payload\": {\n    \"ai_action_summary\": \"提出開放式問題，引導使用者探索願景的關鍵要素。\",\n    \"key_points_from_ai\": \"探索問題涵蓋：目的、影響、未來狀態、獨特性、價值觀、團隊協作、智能策略管理。\"\n  }\n}\n```"
-              }
-            ],
-            role: "model"
-          },
-          finishReason: "STOP",
-          avgLogprobs: -0.24389227353609524
-        }
-      ],
-      modelVersion: "gemini-2.0-flash",
-      usageMetadata: {
-        promptTokenCount: 495,
-        candidatesTokenCount: 520,
-        totalTokenCount: 1015,
-        promptTokensDetails: [
-          {
-            modality: "TEXT",
-            tokenCount: 495
-          }
-        ],
-        candidatesTokensDetails: [
-          {
-            modality: "TEXT",
-            tokenCount: 520
-          }
-        ]
-      }
+    if (!promptText.length) {
+      return;
     }
+    const response = await genaiService.generateContentFromAiStudio(promptText, config.modelName)
     const results: Record<string, any> = {
       llmOutput: response
     }
@@ -71,8 +40,13 @@ export class LLMCallExecutor extends ExecutorBase {
   }
 
   async composePrompt(promptTemplate: string, node: ExecutionNodeDto, tracker: ExecutionContextTracker): Promise<string> {
-    const inputs = this.getInputs(node, tracker)
-    return Object.entries(inputs).reduce((acc, input) => {
+    const inputs = await this.getInputs(node, tracker)
+    const inputEntries = Object.entries(inputs)
+    if (!inputEntries.length) {
+      return '';
+    }
+
+    return inputEntries.reduce((acc, input) => {
       let [key, value] = input
       return acc.replace(`{{${key}}}`, value)
     }, promptTemplate)


### PR DESCRIPTION
Re-enables actual LLM API calls in the `LLMCallExecutor` by removing mock responses and extends the RabbitMQ RPC timeout to accommodate potentially longer LLM response times.

Key changes:
- **Enable Live LLM Calls**: The hardcoded mock response in `LLMCallExecutor` (`libs/caidense-reasoning/src/executor/genai/genai.service.ts`) has been removed. The executor now makes actual calls to the `genaiService.generateContentFromAiStudio` function.
- **Extended RabbitMQ RPC Timeout**: The `RABBITMQ_RPC_TIMEOUT` in `docker-var.env` has been increased from 5000ms to 60000ms. This provides more time for the worker to receive responses from the LLM service, preventing timeouts for longer or more complex generations.
- **Prompt Composition Validation**: Added a check in `composePrompt` to return an empty string if no inputs are available, preventing unnecessary prompt composition attempts. Also added a check in `execute` to return early if `promptText` is empty.
- **Await `getInputs`**: Changed `this.getInputs(node, tracker)` to `await this.getInputs(node, tracker)` in `composePrompt` to correctly handle asynchronous input retrieval.

These changes are crucial for enabling real-world LLM inference within the workflow engine and addressing potential timeout issues that may arise with external API calls.