### PR TITLE
feat(frontend, api, auth): Implement basic user login

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -19,7 +19,7 @@ async function bootstrap() {
     app.enableCors({
       origin: FRONTEND_PORTS.split(',').map(port => `http://localhost:${port}`),
       methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-      allowedHeaders: 'Content-Type, Accept',
+      allowedHeaders: 'Content-Type, Accept, Authorization',
     });
 
     // Enable Swagger for API documentation

--- a/auth/src/main.ts
+++ b/auth/src/main.ts
@@ -19,7 +19,7 @@ async function bootstrap() {
     app.enableCors({
       origin: FRONTEND_PORTS.split(',').map(port => `http://localhost:${port}`),
       methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-      allowedHeaders: 'Content-Type, Accept',
+      allowedHeaders: 'Content-Type, Accept, Authorization',
     });
 
     // Enable Swagger for API documentation
@@ -31,6 +31,7 @@ async function bootstrap() {
       .setTitle('Caidense Synth Auth')
       .setDescription('Provide a robust and systematic platform for managing, templating, testing, and evaluating Large Language Model (LLM) prompts. It aims to bring engineering rigor to the prompt development lifecycle, facilitating better collaboration, version control, testing, and optimization of prompts used in LLM-powered applications.')
       .setVersion('1.0')
+      .addBearerAuth()
       .addServer(`http://localhost:${HOST_PORT}/`, 'Local environment')
       .addTag('Caidense Synth')
       .build();

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,3 @@
 VITE_NODE_ENV=development
 VITE_CAIDENSE_SYNTH_API_URL=http://localhost:3001
+VITE_CAIDENSE_SYNTH_AUTH_URL=http://localhost:3002

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,3 @@
 VITE_NODE_ENV=production
 VITE_CAIDENSE_SYNTH_API_URL=http://localhost:3001
+VITE_CAIDENSE_SYNTH_AUTH_URL=http://localhost:3002

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,11 +1,45 @@
 <script setup lang="ts">
+import FormInput from '@/components/layouts/form/FormInput.vue';
+import FormModal from '@/components/layouts/form/FormModal.vue';
 import Header from '@/components/shared/Header.vue';
+import type { FormInstance } from '@/types/form';
+import { reactive, ref } from 'vue';
 import { RouterView } from 'vue-router';
+import { apiService } from './api/apiService';
+
+
+const formInstance = reactive<Map<string, FormInstance>>(new Map());
+const isLogin = ref<boolean>(sessionStorage.getItem('accessToken') ? true : false);
+const isSubmitLogin = ref<boolean>(false);
+
+const handleLoginSubmit = async () => {
+  const formData = {
+    username: formInstance.get('userName')?.editableContent as string,
+    password: formInstance.get('password')?.editableContent as string,
+  }
+
+  const response = await apiService.auth.login(formData);
+  sessionStorage.setItem('accessToken', response.data.access_token as string);
+  isSubmitLogin.value = false;
+  isLogin.value = true;
+};
+
+const registerRef = async (key:string, instance: any) => {
+  if (instance) {
+    formInstance.set(key, instance)
+  }
+}
 </script>
 
 <template>
   <div class="flex-col no-scrollbar">
-    <Header />
+    <Header :is-login="isLogin" @login="isSubmitLogin = true;" />
     <RouterView />
   </div>
+  <FormModal :is-open="isSubmitLogin" :title="'Configure Node'" :cancel-button-name="'Cancel'" :save-button-name="'Save'" @close="isSubmitLogin = false" @save="handleLoginSubmit">
+    <template #fields>
+      <FormInput :label-name="'User Name'" :label-id="'userName'" :placeholder="'Enter your name'" :ref="el => registerRef('userName', el)" />
+      <FormInput :label-name="'Password'" :label-id="'password'" :placeholder="'Enter your password'" :type="'password'" :ref="el => registerRef('password', el)" />
+    </template>
+  </FormModal>
 </template>

--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -4,16 +4,22 @@ import type { CreatePrompt, Prompt, UpdatePrompt } from '@/types/prompts';
 import type { CreateRepository, Repository, UpdateRepository } from '@/types/repositories';
 import type { CreateExecution, CreateThinking, CreateWorkflow, UpdateThinking, Workflow } from '@/types/workflow';
 import axios, { AxiosResponse } from 'axios';
-import { GenAIEndPoints, NodeEndpoints, PromptEndpoints, RepositoryEndpoints, WorkflowEndpoints } from './endpoints';
+import { AuthEndpoints, GenAIEndPoints, NodeEndpoints, PromptEndpoints, RepositoryEndpoints, WorkflowEndpoints } from './endpoints';
 
 
 const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
+    'Authorization': `Bearer ${sessionStorage.getItem('accessToken')}`
   },
 });
 
 export const apiService = {
+  auth: {
+    login: (data: {username: string; password: string;}): Promise<AxiosResponse> => {
+      return apiClient.post(AuthEndpoints.login(), data);
+    },
+  },
   genai: {
     GoogleAIStudio: (data: GenAIRequest): Promise<AxiosResponse> => {
       return apiClient.post(GenAIEndPoints.GoogleAIStudio(), data);

--- a/frontend/src/api/endpoints/auth.ts
+++ b/frontend/src/api/endpoints/auth.ts
@@ -1,0 +1,8 @@
+import config from '@/config';
+
+
+const CAIDENSE_SYNTH_AUTH_URL = config.CAIDENSE_SYNTH_AUTH_URL || '';
+export const AuthEndpoints = {
+  login: () =>
+    `${CAIDENSE_SYNTH_AUTH_URL}/auth/login`,
+};

--- a/frontend/src/api/endpoints/index.ts
+++ b/frontend/src/api/endpoints/index.ts
@@ -1,3 +1,4 @@
+export * from './auth';
 export * from './block';
 export * from './repository';
 export * from './workflow';

--- a/frontend/src/components/shared/Header.vue
+++ b/frontend/src/components/shared/Header.vue
@@ -1,6 +1,19 @@
-<script setup>
+<script setup lang="ts">
 import { RouterLink } from 'vue-router';
 import { RocketLaunchIcon, FolderIcon, CubeIcon } from '@heroicons/vue/24/outline';
+
+
+const props = defineProps({
+  isLogin: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emits = defineEmits<{
+  (e: 'login'): void;
+}>();
+
 </script>
 
 <template>
@@ -27,12 +40,17 @@ import { RocketLaunchIcon, FolderIcon, CubeIcon } from '@heroicons/vue/24/outlin
         </router-link>
       </div>
 
-      <div class="sm:hidden">
-        <button class="text-gray-600 hover:text-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-          </svg>
+      <div class="hidden sm:flex items-center">
+        <button
+          v-if="!isLogin"
+          @click="$emit('login')"
+          class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition duration-150 ease-in-out"
+        >
+          Log In
         </button>
+        <div v-else class="relative w-10 h-10 overflow-hidden bg-gray-100 rounded-full dark:bg-gray-600">
+          <svg class="absolute w-12 h-12 text-gray-400 -left-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path></svg>
+        </div>
       </div>
     </nav>
   </header>

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -1,12 +1,14 @@
 interface RuntimeConfig {
   NODE_ENV: 'development' | 'production' | 'test';
   CAIDENSE_SYNTH_API_URL: string;
+  CAIDENSE_SYNTH_AUTH_URL: string;
 }
 
 
 const config: RuntimeConfig = {
   NODE_ENV: import.meta.env.VITE_NODE_ENV as RuntimeConfig['NODE_ENV'],
   CAIDENSE_SYNTH_API_URL: import.meta.env.VITE_CAIDENSE_SYNTH_API_URL as string,
+  CAIDENSE_SYNTH_AUTH_URL: import.meta.env.VITE_CAIDENSE_SYNTH_AUTH_URL as string,
 };
 
 export default config;

--- a/frontend/src/types/vite-env.d.ts
+++ b/frontend/src/types/vite-env.d.ts
@@ -1,6 +1,7 @@
 interface ImportMetaEnv {
   readonly VITE_NODE_ENV: 'development' | 'production' | 'test';
   readonly VITE_CAIDENSE_SYNTH_API_URL: string;
+  readonly VITE_CAIDENSE_SYNTH_AUTH_URL: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This commit introduces basic user login functionality in the frontend, allowing users to authenticate with the backend.

Key changes include:
- **frontend:**
    - Implemented a login modal in `App.vue` to capture username and password.
    - Added a `login` method to the `auth` section in `apiService.ts` to call the authentication service's login endpoint.
    - Updated the `Header` component to include a "Log In" button when the user is not authenticated and a placeholder user icon when logged in.
    - Created a new `AuthEndpoints` object in `frontend/src/api/endpoints/auth.ts` to define the login endpoint URL, using the `VITE_CAIDENSE_SYNTH_AUTH_URL` environment variable.
    - Updated the CORS configuration in both API and Auth services to allow the `Authorization` header.
    - Updated environment variable configurations to include `VITE_CAIDENSE_SYNTH_AUTH_URL`.
- **api:**
    - Updated the CORS configuration to allow the `Authorization` header.
- **auth:**
    - Updated the CORS configuration to allow the `Authorization` header and added `.addBearerAuth()` to the Swagger documentation.
- Added `VITE_CAIDENSE_SYNTH_AUTH_URL` to frontend environment files and types.

This initial implementation allows users to log in to the application, paving the way for securing further functionalities.